### PR TITLE
Add Gemfile and workflow update

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           ruby-version: '3.1'
       - run: |
-          gem install jekyll jekyll-theme-cayman
-          jekyll build
+          bundle install
+          bundle exec jekyll build
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ _site/
 .jekyll-cache/
 
 # ignore Ruby bundler config
-Gemfile
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+gem 'jekyll-theme-cayman'

--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@
   </a>
 </h2>
 <br>
+
+## Local development
+
+To run the site locally:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```


### PR DESCRIPTION
## Summary
- add Gemfile to manage Jekyll dependencies
- allow Gemfile in `.gitignore`
- update GitHub Actions workflow to use Bundler
- document how to run the site locally in README

## Testing
- `bundle install --path vendor/bundle`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68445af0b0a0832788fd40b19ab1750c