### PR TITLE
Fix long lines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 <h1 align="center">Hallo 👋, Ich bin Veer</h1>
 <h3 align="center">A passionate developer from India</h3>
 
-![Hello programmer Welcome to my profile](https://img.shields.io/badge/Hello!-Welcome<3-orange.svg?style=flat&logo=github) 
+<img alt="Hello programmer Welcome to my profile"
+     src="https://img.shields.io/badge/Hello!-Welcome<3-orange.svg?style=flat&logo=github">
 
 <p align="left"> <img src="https://komarev.com/ghpvc/?username=mads5" alt="mads5" /> </p>
 
@@ -17,23 +18,93 @@
 <p align="left">
 <h3 align="left">Connect with me:</h3>
 
-<a href="https://linkedin.com/in/veerkalantri" target="_blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg" alt="veerkalantri" height="30" width="40" /></a>
+<a href="https://linkedin.com/in/veerkalantri" target="_blank">
+  <img align="center"
+       src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg"
+       alt="veerkalantri" height="30" width="40" />
+</a>
 
-<a href="https://www.youtube.com/user/5mads" target="_blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/youtube.svg" alt="5mads" height="30" width="40" /></a>
+<a href="https://www.youtube.com/user/5mads" target="_blank">
+  <img align="center"
+       src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/youtube.svg"
+       alt="5mads" height="30" width="40" />
+</a>
 </p>
 
 <h3 align="left">Languages and Tools:</h3>
-<p align="left"> <a href="https://www.cprogramming.com/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/c/c-original.svg" alt="c" width="40" height="40"/> </a> <a href="https://www.w3schools.com/cpp/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg" alt="cplusplus" width="40" height="40"/> </a> <a href="https://www.w3schools.com/css/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg" alt="css3" width="40" height="40"/> </a> <a href="https://www.djangoproject.com/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/django/django-plain.svg" alt="django" width="40" height="40"/> </a> <a href="https://www.w3.org/html/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" alt="html5" width="40" height="40"/> </a> <a href="https://www.linux.org/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-plain.svg" alt="linux" width="40" height="40"/> </a> <a href="https://www.mysql.com/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original.svg" alt="mysql" width="40" height="40"/> </a> <a href="https://opencv.org/" target="_blank"> <img src="https://www.vectorlogo.zone/logos/opencv/opencv-icon.svg" alt="opencv" width="40" height="40"/> </a> <a href="https://www.oracle.com/" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/oracle/oracle-original.svg" alt="oracle" width="40" height="40"/> </a> <a href="https://www.python.org" target="_blank"> <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="python" width="40" height="40"/></a></p> 
+<p align="left">
+  <a href="https://www.cprogramming.com/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/c/c-original.svg"
+      alt="c" width="40" height="40"/>
+  </a>
+  <a href="https://www.w3schools.com/cpp/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg"
+      alt="cplusplus" width="40" height="40"/>
+  </a>
+  <a href="https://www.w3schools.com/css/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg"
+      alt="css3" width="40" height="40"/>
+  </a>
+  <a href="https://www.djangoproject.com/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/django/django-plain.svg"
+      alt="django" width="40" height="40"/>
+  </a>
+  <a href="https://www.w3.org/html/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg"
+      alt="html5" width="40" height="40"/>
+  </a>
+  <a href="https://www.linux.org/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-plain.svg"
+      alt="linux" width="40" height="40"/>
+  </a>
+  <a href="https://www.mysql.com/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original.svg"
+      alt="mysql" width="40" height="40"/>
+  </a>
+  <a href="https://opencv.org/" target="_blank">
+    <img
+      src="https://www.vectorlogo.zone/logos/opencv/opencv-icon.svg"
+      alt="opencv" width="40" height="40"/>
+  </a>
+  <a href="https://www.oracle.com/" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/oracle/oracle-original.svg"
+      alt="oracle" width="40" height="40"/>
+  </a>
+  <a href="https://www.python.org" target="_blank">
+    <img
+      src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg"
+      alt="python" width="40" height="40"/>
+  </a>
+</p>
 
-<p><img align="left" src="https://github-readme-stats.vercel.app/api/top-langs/?username=mads5&layout=compact" alt="mads5" /></p>
+<p>
+  <img align="left"
+       src="https://github-readme-stats.vercel.app/api/top-langs/?username=mads5&layout=compact"
+       alt="mads5" />
+</p>
 
-<p>&nbsp;<img align="center" src="https://github-readme-stats.vercel.app/api?username=mads5&show_icons=true" alt="mads5" /></p>
+<p>&nbsp;
+  <img align="center"
+       src="https://github-readme-stats.vercel.app/api?username=mads5&show_icons=true"
+       alt="mads5" />
+</p>
 
 <h3 align="center">Show ❤️ By Starring My Repos!</h3>
 <h4 align="center"> or </h4>
 <h2 align="center">
   <a href="https://bmc.link/veerk" target="_blank" style="display:inline-flex;align-items:center;text-decoration:none;">
-    <img src="https://raw.githubusercontent.com/mads5/mads5/master/clipboard.ico" alt="Buy Me a Coffee" width="40" height="40" style="margin-right:0.4em;">
+    <img src="
+      https://raw.githubusercontent.com/mads5/mads5/master/clipboard.ico"
+         alt="Buy Me a Coffee" width="40" height="40"
+         style="margin-right:0.4em;">
     Buy Me a Coffee
   </a>
 </h2>


### PR DESCRIPTION
## Summary
- break up overly long HTML lines in README
- keep markup output unchanged

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68445cf0a70483279e8df99dfec5134d