### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -15,4 +15,10 @@ jobs:
       - run: |
           bundle install
           bundle exec jekyll build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          publish_branch: gh-pages
 

--- a/README.md
+++ b/README.md
@@ -118,3 +118,10 @@ To run the site locally:
 bundle install
 bundle exec jekyll serve
 ```
+
+## Deployment
+
+The site is automatically published using
+[peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages).
+Whenever changes land in the repository, the GitHub Actions workflow builds the
+site and pushes the contents of the `_site` directory to the `gh-pages` branch.


### PR DESCRIPTION
## Summary
- deploy the `_site` directory using `peaceiris/actions-gh-pages`
- document deployment via GitHub Actions

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_684461ba60d88327931a6330af6a8d4e