### PR TITLE
Update README with website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,7 @@ The site is automatically published using
 [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages).
 Whenever changes land in the repository, the GitHub Actions workflow builds the
 site and pushes the contents of the `_site` directory to the `gh-pages` branch.
+
+## Website
+
+Visit the live site at [https://mads5.github.io/mads5/](https://mads5.github.io/mads5/). It auto-deploys from the `gh-pages` branch.


### PR DESCRIPTION
## Summary
- add a Website section with GitHub Pages link

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6844668b9c948327b584b6a4c9c21fa6