### PR TITLE
Add force_orphan flag for gh-pages publishing

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -21,4 +21,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           publish_branch: gh-pages
+          force_orphan: true
 


### PR DESCRIPTION
## Summary
- ensure `gh-pages` updates even if the branch diverged

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_684466946ddc8327b62514339a22b540